### PR TITLE
Fix pnpm lockfile error in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --no-frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud


### PR DESCRIPTION
This pull request fixes an error in the CI workflow where the pnpm install command was failing when the pnpm-lock.yaml file was absent. The pnpm install command has been updated to use --no-frozen-lockfile to ensure that dependencies are installed correctly in CI environments.