### PR TITLE
ci: update node version management in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: package.json
           cache: 'pnpm'
 
       - uses: nrwl/nx-set-shas@v4

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "@nx/workspace": "19.7.4",
     "nx": "19.7.4"
   },
-  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
+  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c",
+  "engines": {
+    "node": ">=20.15.1"
+  }
 }


### PR DESCRIPTION
This pull request updates the node version management in the CI workflow. It changes the node version management to use node-version-file in ci.yml and adds an engines field to package.json to specify a node version of >=20.15.1.