### PR TITLE
chore: update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,18 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4.0.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.0.4
         with:
           node-version-file: package.json
           cache: pnpm
 
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@v4.1.0
 
       - run: >
           pnpm dlx nx-cloud start-ci-run \


### PR DESCRIPTION
This pull request updates the versions of the following GitHub Actions:

- actions/checkout to v4.1.7
- pnpm/action-setup to v4.0.0
- actions/setup-node to v4.0.4
- nrwl/nx-set-shas to v4.1.0

These updates ensure that we are using the latest versions of these actions, which may include important bug fixes and performance improvements.