### PR TITLE
chore: add NX Cloud environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
+
 on:
   push:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Thumbs.db
 
 .nx/cache
 .nx/workspace-data
+nx-cloud.env


### PR DESCRIPTION
This pull request adds NX Cloud environment variables to the CI workflow:
- `NX_CLOUD_ACCESS_TOKEN`
- `NX_CLOUD_ENCRYPTION_KEY`

Additionally, the `.gitignore` file has been updated to include `nx-cloud.env`.

These changes are necessary to ensure that the CI pipeline can securely access NX Cloud services and that sensitive environment files are not tracked in the repository.