### PR TITLE
chore: improve CI performance with --runInBand flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
       - run: >
           pnpm dlx nx-cloud start-ci-run \
           --distribute-on .nx/workflows/dynamic-changesets.yaml \
-          --stop-agents-after build
+          --stop-agents-after e2e-ci
 
       - run: pnpm install --no-frozen-lockfile
 
-      - run: pnpm exec nx affected -t lint test build --parallel $(nproc)
+      - run: pnpm exec nx affected -t lint build --parallel=$(nproc)
+      - run: pnpm exec nx affected -t test e2e-ci --parallel=$(nproc) -- --runInBand


### PR DESCRIPTION
This pull request updates the CI workflow to improve performance by
running Jest tests in a single process using the --runInBand flag.
This change prevents the creation of too many processes, which can
slow down the system.

Changes include:
- Updated the CI workflow to use --runInBand flag for Jest tests.
- Adjusted the stop-agents-after parameter to e2e-ci.