### PR TITLE
chore: enable inference plugins in nx.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,5 +15,6 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudId": "66eb5e5860432e7b196e5681"
+  "nxCloudId": "66eb5e5860432e7b196e5681",
+  "useInferencePlugins": true
 }


### PR DESCRIPTION
This pull request adds the `useInferencePlugins` option to `nx.json`, allowing for the use of inference plugins. This change improves the management and inference of project configurations.