### PR TITLE
fix(codeql): set build-mode to none for JS/TS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - language: javascript-typescript
-            build-mode: autobuild
+            build-mode: none
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
The build-mode for JavaScript/TypeScript in the CodeQL workflow has been updated to "none" to resolve a fatal error encountered during the CodeQL database initialization.