### PR TITLE
Update pnpm version to 9.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@nx/workspace": "19.8.2",
     "nx": "19.8.2"
   },
-  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c",
+  "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b",
   "engines": {
     "node": ">=20.15.1"
   }


### PR DESCRIPTION
This pull request updates the pnpm package manager version from 9.10.0 to 9.11.0 in the package.json file.